### PR TITLE
Update mm-decode-history-page.py

### DIFF
--- a/bin/mm-decode-history-page.py
+++ b/bin/mm-decode-history-page.py
@@ -10,6 +10,8 @@ from binascii import hexlify
 # from datetime import datetime
 # from scapy.all import *
 import json
+import datetime
+json.JSONEncoder.default = lambda self,obj: (obj.isoformat() if isinstance(obj, datetime.datetime) else None)
 
 from decocare import lib, history, models
 


### PR DESCRIPTION
fix python induced json parsing errors (datetime) on certain records in pump history - see issue in bewest/decocare
