### PR TITLE
decode overflow bit when insulin sensitivity > 255

### DIFF
--- a/decocare/commands.py
+++ b/decocare/commands.py
@@ -1030,15 +1030,16 @@ class ReadInsulinSensitivities (PumpCommand):
     data = self.data[1:1+16]
     schedule = [ ]
     for x in range(8):
-      # Each entry in the sensitivity schedule consists of 2 bytes. The first byte is used as follows:
-      #   bits 0-2 are 0
-      #   bit 3 is in overflow bit that is set when sensitivity is > 255
-      #   bits 4-7 represent the scheduled time 
+      # Each entry in the sensitivity schedule consists of 2 bytes.
+      # The first byte is used as follows:
+      #   - the highest bit is 0
+      #   - the next highest bit is an overflow bit that is set when the sensitivity is > 255
+      #   - the low 6 bits are an index from 0-47 representing the scheduled time
       # The second byte is the insulin sensitivity. When the sensitivity is >255, the overflow bit above will be set and this byte will
       # show the remainder (e.g. for 256 the overflow bit will be set and this byte will be 0).
       start = x * 2
-      i = data[start] & 0x0F
-      sensitivity_overflow = (data[start] & 0xF0) << 4
+      i = data[start] & 0x3F
+      sensitivity_overflow = (data[start] & 0x40) << 2
       sensitivity = data[start+1] + sensitivity_overflow
       if x > 0 and i == 0:
         break

--- a/decocare/commands.py
+++ b/decocare/commands.py
@@ -1030,9 +1030,16 @@ class ReadInsulinSensitivities (PumpCommand):
     data = self.data[1:1+16]
     schedule = [ ]
     for x in range(8):
+      # Each entry in the sensitivity schedule consists of 2 bytes. The first byte is used as follows:
+      #   bits 0-2 are 0
+      #   bit 3 is in overflow bit that is set when sensitivity is > 255
+      #   bits 4-7 represent the scheduled time 
+      # The second byte is the insulin sensitivity. When the sensitivity is >255, the overflow bit above will be set and this byte will
+      # show the remainder (e.g. for 256 the overflow bit will be set and this byte will be 0).
       start = x * 2
-      end = start + 2
-      (i, sensitivity) = data[start:end]
+      i = data[start] & 0x11
+      sensitivity_overflow = data[start] & 0x100
+      sensitivity = data[start+1] + sensitivity_overflow
       if x > 0 and i == 0:
         break
       if units == 2:

--- a/decocare/commands.py
+++ b/decocare/commands.py
@@ -1037,8 +1037,8 @@ class ReadInsulinSensitivities (PumpCommand):
       # The second byte is the insulin sensitivity. When the sensitivity is >255, the overflow bit above will be set and this byte will
       # show the remainder (e.g. for 256 the overflow bit will be set and this byte will be 0).
       start = x * 2
-      i = data[start] & 0x11
-      sensitivity_overflow = data[start] & 0x100
+      i = data[start] & 0x0F
+      sensitivity_overflow = (data[start] & 0xF0) << 4
       sensitivity = data[start+1] + sensitivity_overflow
       if x > 0 and i == 0:
         break


### PR DESCRIPTION
When insulin sensitivity is above 255, there is an additional overflow bit that gets set which the code wasn't handling. The bit was previously being decoded as part of the time component, so both the time and the sensitivity were wrong for high sensitivities.

I verified this fix on a 523 pump. #5 
