### PR TITLE
Remove 10-Something from independent record elif

### DIFF
--- a/decocare/cgm/__init__.py
+++ b/decocare/cgm/__init__.py
@@ -173,7 +173,7 @@ class PagedData (object):
             record.update(waiting='meter_bg_now')
         prefix_records.append(record)
 
-      elif record['name'] == 'SensorTimestamp' or record['name'] == 'SensorCalFactor' or record['name'] in ['10-Something' ]:
+      elif record['name'] == 'SensorTimestamp' or record['name'] == 'SensorCalFactor' or record['name'] in ['10-Something']:
         # TODO: maybe this is like a ResetGlucose base command
         # these are sensor minute timestamped records thus create the record
         # and map prefixed elements based on the timedelta
@@ -202,7 +202,7 @@ class PagedData (object):
         prefix_records = []
 
 
-      elif record['name'] in ['SensorStatus', 'DateTimeChange', 'SensorSync', '10-Something', 'CalBGForGH', 'BatteryChange' ]:
+      elif record['name'] in ['SensorStatus', 'DateTimeChange', 'SensorSync', 'CalBGForGH', 'BatteryChange' ]:
         # independent record => parse and add to records list
         record.update(raw=self.byte_to_str(raw_packet))
         if record['name'] in ['SensorStatus', 'SensorSync', 'CalBGForGH', 'BatteryChange', 'DateTimeChange']:


### PR DESCRIPTION
As I was reading through the cgm page parsing code, I noticed that 10-Something appears in two different elif branches. It appears that the latter one will never be reached for the 10-Something op code (or I misunderstand how the cgm record parsing is supposed to work). This PR removes the second 10-Something to make the code clearer to readers who come after me.

Running list_cgm.py with a page of data including 10-Something records resulted in identical output to the code without this change.
