### PR TITLE
Ignore null opcode bytes within a cgm page

### DIFF
--- a/decocare/cgm/__init__.py
+++ b/decocare/cgm/__init__.py
@@ -152,6 +152,11 @@ class PagedData (object):
     prefix_records = []
     for B in iter(lambda: self.stream.read(1), ""):
       B = bytearray(B)
+
+      # eat nulls within the page to avoid 0-value sgv records
+      if B[0] == 0x00:
+        continue
+
       record = self.suggest(B[0])
       record['_tell'] = self.stream.tell( )
       # read packet if needed


### PR DESCRIPTION
This PR changes the cgm page decoding to ignore null opcode bytes throughout a cgm page.

Background: While decoding cgm pages and examining the output, I noticed a recurring pattern of two 0-value GlucoseSensor records followed by a DataEnd in some of the pages (See json output example below). It looks like some subset of pumps append two null bytes after a DataEnd (0x01) record. These two bytes are being identified as sgv records with a value of 0. 

I made the change in this PR to ignore nulls within a page and ran a before/after diff of every glucose page in the repo I could find. In each diff, the two sgv records are no longer present and the corresponding DataEnd record has a timestamp 10 minutes earlier (since the two glucose records are no longer offsetting the DataEnd relative timestamp).

```
  {
    "name": "GlucoseSensorData", 
    "date_type": "prevTimestamp", 
    "_tell": 235, 
    "sgv": 0, 
    "date": "2015-04-29T07:43:00", 
    "packet_size": 0, 
    "op": 0
  }, 
  {
    "name": "GlucoseSensorData", 
    "date_type": "prevTimestamp", 
    "_tell": 234, 
    "sgv": 0, 
    "date": "2015-04-29T07:48:00", 
    "packet_size": 0, 
    "op": 0
  }, 
  {
    "packet_size": 0, 
    "name": "DataEnd", 
    "date": "2015-04-29T07:53:00", 
    "date_type": "none", 
    "_tell": 233, 
    "op": "0x01"
  }
```
