### PR TITLE
Support for temp basals >= 6.4 U/hr

### DIFF
--- a/decocare/commands.py
+++ b/decocare/commands.py
@@ -294,7 +294,7 @@ class TempBasal(PumpCommand):
   def format_params (klass, rate, duration):
     duration = duration / 30
     rate = int(round(rate / 0.025))
-    params = [0x00, rate, duration]
+    params = [lib.HighByte(rate), lib.LowByte(rate), duration]
     return params
 
 

--- a/decocare/history.py
+++ b/decocare/history.py
@@ -186,7 +186,7 @@ class TempBasal (KnownRecord):
     temp = { 0: 'absolute', 1: 'percent' }[(self.body[0] >> 3)]
     status = dict(temp=temp)
     if temp is 'absolute':
-      rate = self.head[1] / 40.0
+      rate = lib.BangInt([self.body[0]&0x7, self.head[1]]) / 40.0
       status.update(rate=rate)
     if temp is 'percent':
       rate = int(self.head[1])


### PR DESCRIPTION
Pass high and low bytes of absolute rate to the TempBasal command.
Fixes https://github.com/bewest/decoding-carelink/issues/116
