### PR TITLE
bolus ack

### DIFF
--- a/decocare/commands.py
+++ b/decocare/commands.py
@@ -475,8 +475,13 @@ class Bolus (PumpCommand):
   descr = "Bolus"
   params = [ ]
   def getData(self):
-    received = True if self.data[0] is 0x0c else False
-    return dict(recieved=received, _type='BolusRequest')
+    # received = True if self.data[0] is 0x0c else False
+    received = False
+    if bytearray(64) == self.data:
+      received = True
+    if len(self.data) and self.data[-1] == 0x0c:
+      received = True
+    return dict(recieved=received, _type='BolusRequest', raw=str(self.data).encode('hex'))
 
 
 class ReadErrorStatus(PumpCommand):

--- a/decocare/commands.py
+++ b/decocare/commands.py
@@ -12,8 +12,8 @@ class BadResponse (Exception):
 Implementation and decoding of lots of commands.
 
 Each command inherits from :py:`BaseCommand`, which takes care of the
-basic logic for informing the stick if we have recieved all the data
-we expect to recieve.
+basic logic for informing the stick if we have received all the data
+we expect to receive.
 
 Many commands are supported by Medtronic but not listed here.
 Examples would include setting profiles and rates.
@@ -274,7 +274,7 @@ class TempBasal(PumpCommand):
   def getData(self):
     status = { 0: 'absolute' }
     received = True if (len(self.data) > 0 and self.data[0] is 0) else False
-    return dict(recieved=received, temp=status.get(self.params[0], 'percent'))
+    return dict(received=received, temp=status.get(self.params[0], 'percent'))
   @classmethod
   def Program (klass, rate=None, duration=None, temp=None, **kwds):
     assert duration % 30 is 0, "duration {0} is not a whole multiple of 30".format(duration)
@@ -308,7 +308,7 @@ class SetSuspend(PumpCommand):
   def getData(self):
     status = { 0: 'resumed', 1: 'suspended' }
     received = True if self.data[0] is 0 else False
-    return dict(recieved=received, status=status.get(self.params[0]))
+    return dict(received=received, status=status.get(self.params[0]))
 
 class PumpSuspend(SetSuspend):
   descr = "Suspend pump"
@@ -481,7 +481,7 @@ class Bolus (PumpCommand):
       received = True
     if len(self.data) and self.data[-1] == 0x0c:
       received = True
-    return dict(recieved=received, _type='BolusRequest', raw=str(self.data).encode('hex'))
+    return dict(received=received, _type='BolusRequest', raw=str(self.data).encode('hex'))
 
 
 class ReadErrorStatus(PumpCommand):

--- a/decocare/models/__init__.py
+++ b/decocare/models/__init__.py
@@ -220,7 +220,7 @@ class PumpModel (object):
   def set_temp_basal (self, rate=None, duration=None, temp=None, **kwds):
     basals = dict(rate=rate, duration=duration, temp=temp)
     result = self._set_temp_basal(**basals)
-    if not result.get('recieved'):
+    if not result.get('received'):
       result.update(requested=basals)
     result.update(**self.read_temp_basal( ))
     return result

--- a/decocare/stick.py
+++ b/decocare/stick.py
@@ -38,7 +38,7 @@ class StickCommand(object):
   associated with the opcode.
   Altogether, the suite of opcodes that the stick responds to allows
   you to debug and track all packets you are sending/receiving plus
-  allows you to send recieve commands to the pump, by formatting your
+  allows you to send receive commands to the pump, by formatting your
   message into payloads with opcodes, and then letting the stick work
   on what you've given it.  It's kind of like a modem with this funky
   binary interface and 64 byte payloads.

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def readme():
         return f.read()
 
 setup(name='decocare',
-    version='0.0.32-dev', # http://semver.org/
+    version='0.1.0-dev', # http://semver.org/
     description='Audit, inspect, and command MM insulin pumps.',
     long_description=readme(),
     author="Ben West",


### PR DESCRIPTION
mmeowlink and Carelink stick do slightly different things:
- Carelink always returns a payload, even when no payload exists,
  apparently to convey error status?
- Mmeowlink exposes the acks per frame, but we observe no payload
  in the RF, therefore we generate a fictitious 64 byte null
  payload.

I've seen following successful fictious payloads from Carelink usb:
  0x00 0x00
  0x00
  0x0c
  0x00 0x0c

I've seen the following unsuccessful failure payloads from
Carelink usb (eg exceeding the max bolus limit):
  0x09
  0x09 0x09

---

Please do special testing on this, it's related to https://github.com/openaps/decocare/issues/4
