### PR TITLE
Expect a body of 32 bytes for ChangeBolusWizardSetup records

### DIFF
--- a/decocare/history.py
+++ b/decocare/history.py
@@ -225,7 +225,7 @@ class ChangeTimeDisplay(KnownRecord):
 
 class ChangeBolusWizardSetup (KnownRecord):
   opcode = 0x4f
-  body_length = 40
+  body_length = 32
 
 _confirmed = [ Bolus, Prime, AlarmPump, ResultDailyTotal,
                ChangeBasalProfile_old_profile,


### PR DESCRIPTION
As described in https://github.com/openaps/decocare/issues/19, this is a change to the ChangeBoluzWizardSetup record to expect the body to be 32 bytes instead of 40. Making this changes causes the history page in question to be decoded properly (see comment below with parser output - RECORD 24 ChangeBolusWizardSetup 2017-02-14T09:33:12 head[2], body[32] op[0x4f]).

Raw history page: https://gist.github.com/tmecklem/d47c1dae50a7b29e2b059f9491f0f24c