### PR TITLE
Use correct units when parsing BolusWizard & CallBGForPH records

### DIFF
--- a/decocare/models/__init__.py
+++ b/decocare/models/__init__.py
@@ -77,7 +77,6 @@ class PageIterator (Task):
 class PumpModel (object):
   bolus_strokes = 20
   basal_strokes = 40
-  MMOL_DEFAULT = False
   larger = False
   Ian50Body = 30
   def __init__(self, model, session):
@@ -237,7 +236,6 @@ class PumpModel (object):
 
 
 class Model508 (PumpModel):
-  MMOL_DEFAULT = False
   old6cBody = 31
   # XXX: hack to return something.
   def read_status (self, **kwds):
@@ -262,29 +260,24 @@ class Model511 (Model508):
 
 
 class Model512 (Model511):
-  MMOL_DEFAULT = False
   read_basal_profile_std = Task(commands.ReadProfile_STD512)
   read_basal_profile_a = Task(commands.ReadProfile_A512)
   read_basal_profile_b = Task(commands.ReadProfile_B512)
 
 
 class Model515 (Model512):
-  MMOL_DEFAULT = False
   read_bg_targets = Task(commands.ReadBGTargets515)
   read_status = Task(commands.ReadPumpStatus)
   pass
 
 class Model715 (Model515):
-  MMOL_DEFAULT = False
   pass
 
 class Model522 (Model515):
-  MMOL_DEFAULT = False
   old6cBody = 38
   pass
 
 class Model722 (Model522):
-  MMOL_DEFAULT = False
   pass
 
 class Model523 (Model522):
@@ -306,27 +299,21 @@ class Model730 (Model530):
   pass
 
 class Model540 (Model530):
-  MMOL_DEFAULT = True
   pass
 
 class Model740 (Model540):
-  MMOL_DEFAULT = True
   pass
 
 class Model551 (Model540):
-  MMOL_DEFAULT = True
   pass
 
 class Model751 (Model551):
-  MMOL_DEFAULT = True
   pass
 
 class Model554 (Model551):
-  MMOL_DEFAULT = True
   pass
 
 class Model754 (Model554):
-  MMOL_DEFAULT = True
   pass
 
 known = {

--- a/decocare/records/bolus.py
+++ b/decocare/records/bolus.py
@@ -85,7 +85,6 @@ class BolusWizard(KnownRecord):
   def __init__(self, head, model=None):
     super(BolusWizard, self).__init__(head, model)
     # self.larger = larger
-    self.MMOL_DEFAULT = model.MMOL_DEFAULT
     if self.larger:
       self.body_length = 15
   def decode(self):
@@ -138,7 +137,9 @@ class BolusWizard(KnownRecord):
                  # 'unknown_bytes': map(int, list(self.body)),
                }
 
-    if self.MMOL_DEFAULT:
+    # 1 == mg/dl, 2 == mmol/L
+    unit = (self.body[1] & 0xC0) >> 6
+    if (unit == 2):
       for key in [ 'bg', 'bg_target_high', 'bg_target_low', 'sensitivity' ]:
         wizard[key] = wizard[key] / 10.0
     return wizard

--- a/decocare/records/bolus.py
+++ b/decocare/records/bolus.py
@@ -235,6 +235,12 @@ class CalBGForPH(KnownRecord):
     nibble = (self.date[4] & 0b10000000) << 1
     low = self.head[1]
     amount = int(highbit + nibble + low)
+    unit = (self.date[2] & 0x60) >> 5
+
+    # 1 == mg/dl, 2 == mmol/L
+    if (unit == 2):
+        amount = amount / 10.0
+
     return { 'amount': amount }
     # return { 'amount': int(lib.BangInt([ year_bits[0], self.head[1] ])) }
     pass


### PR DESCRIPTION
As discussed in issue #8, the processing of these record was previously hardcoded to a specific type of unit depending on the model. For the context, we own both a 722 & 522 and we are using mmol/L but these two models were hardcoded to mg/dl.

Tested on my 722, on which I issued consecutive boluses using the wizard, switching the unit in between.
"openaps use pump iter_pump" correctly displayed the different records in the unit in which they were entered.